### PR TITLE
Publishing package to hex.pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Base64Url
 ==============
 
+[![Hex.pm](https://img.shields.io/hexpm/v/base64url.svg)](https://hex.pm/packages/base64url)
+
 Standalone [URL safe](http://tools.ietf.org/html/rfc4648) base64-compatible codec.
 
 Usage

--- a/src/base64url.app.src
+++ b/src/base64url.app.src
@@ -1,10 +1,14 @@
 {application, base64url, [
   {description, "URL safe base64-compatible codec"},
   {vsn, "0.0.1"},
+  {id, "git"},
   {registered, []},
   {applications, [
     kernel,
     stdlib
   ]},
-  {env, []}
+  {env, []},
+  {contributors, ["Vladimir Dronnikov"]},
+  {licenses, ["MIT"]},
+  {links, [{"Github", "https://github.com/dvv/base64url"}]}
 ]}.


### PR DESCRIPTION
I made some minor changes so I could publish this package on [hex.pm](https://hex.pm/).  I'm using it as a dependency in my [jose](https://github.com/potatosalad/erlang-jose) project (JSON Object Signing and Encryption).

**Edit:** Forgot to mention: thank you for the excellent library! :smile:
